### PR TITLE
version 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,8 @@
 - Pitch randomization for pickup sound.
 - Changed the import defaults for wav files to stop automatic looping.
 - Added polyphony to player's AudioStreamPlayer2D node to allow for 10 sounds to play at the same time.
+
+# version 0.24
+- Fixed a bug where the scene would transition back to the main menu automatically when the game loads.
+- Bug was due to the lack of a type check in pit.gd, where upon any body being detected the pit would transition the scene. The pit was detecting part of the tilemap and transitioned the scene back to the main menu.
+- I have changed it to check if the body detected is a part of the "Player" group and tested to make sure that the pit still functioned nominally with the player.

--- a/scripts/pit.gd
+++ b/scripts/pit.gd
@@ -4,4 +4,5 @@ var next_scene = "res://scenes/testScenes/main_menu.tscn"
 
 func _on_body_entered(body):
 	print("player but body")
-	Globals.change_scene(load(next_scene))
+	if body.is_in_group("Player"):
+		Globals.change_scene(load(next_scene))


### PR DESCRIPTION
- Fixed a bug where the scene would transition back to the main menu automatically when the game loads.
- Bug was due to the lack of a type check in pit.gd, where upon any body being detected the pit would transition the scene. The pit was detecting part of the tilemap and transitioned the scene back to the main menu.
- I have changed it to check if the body detected is a part of the "Player" group and tested to make sure that the pit still functioned nominally with the player.
- Could be worth checking why the pit was detecting the tilemap at all, just to assure the scenario where the pit is always visible and reachable for the player.