### PR TITLE
version 0.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,3 +180,8 @@
 
 -   Added CSV file importing for Upgrade Manager
 -   HUD now starts at Lvl 0
+
+## version 0.39
+-   Upgrades now have a space for icons
+-   Fixed upgrade menu going behind HUD
+-   Merged in the foundation of the Options menu from the branch `jackson-jack-options`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,3 +185,4 @@
 -   Upgrades now have a space for icons
 -   Fixed upgrade menu going behind HUD
 -   Merged in the foundation of the Options menu from the branch `jackson-jack-options`
+-   Changed hotspot for cursor to better match the tip of the sword image.

--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,7 @@ window/size/window_width_override=1920
 window/size/window_height_override=1080
 window/stretch/mode="viewport"
 mouse_cursor/custom_image="res://assets/images/cursorV1.png"
+mouse_cursor/custom_image_hotspot=Vector2(24, 0)
 
 [global_group]
 

--- a/scenes/prefabs/ui_elements/HUD.tscn
+++ b/scenes/prefabs/ui_elements/HUD.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://bxevwqt0bicpt" path="res://assets/sprites/sexyIndiDevLogo.png" id="2_cbqub"]
 [ext_resource type="Texture2D" uid="uid://cb3ihhfb8trsd" path="res://assets/ui_renders/hud-transparentbg.png" id="3_2oo5a"]
 [ext_resource type="PackedScene" uid="uid://bsmerj830lma6" path="res://scenes/prefabs/ui_elements/stat_upgrade_ui.tscn" id="4_0nay5"]
-[ext_resource type="PackedScene" uid="uid://c05l3ridoi3lc" path="res://scenes/prefabs/ui_elements/pause_menu.tscn" id="5_csnww"]
+[ext_resource type="PackedScene" uid="uid://bqwbdvntcsrc0" path="res://scenes/prefabs/ui_elements/pause_menu.tscn" id="5_csnww"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8sjnk"]
 bg_color = Color(1, 0, 0, 1)
@@ -32,9 +32,12 @@ offset_right = 38.0
 offset_bottom = -15.0
 
 [node name="Border" type="Control" parent="."]
-anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="PlayerInfo" type="PanelContainer" parent="Border"]
 layout_mode = 1
@@ -132,14 +135,6 @@ offset_bottom = 1021.62
 grow_vertical = 0
 text = "Upgrade Menu"
 
-[node name="PauseMenu" parent="Border" instance=ExtResource("5_csnww")]
-visible = false
-layout_mode = 1
-offset_left = -158.25
-offset_top = -67.375
-offset_right = -158.25
-offset_bottom = -67.375
-
 [node name="Currency" type="HBoxContainer" parent="Border"]
 layout_mode = 2
 offset_left = 1557.0
@@ -163,5 +158,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.75
 text = "0"
+
+[node name="PauseMenu" parent="." instance=ExtResource("5_csnww")]
+visible = false
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
 
 [connection signal="pressed" from="Border/Button" to="." method="_on_button_pressed"]

--- a/scenes/prefabs/ui_elements/HUD.tscn
+++ b/scenes/prefabs/ui_elements/HUD.tscn
@@ -23,14 +23,6 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_ndg1h")
 
-[node name="StatUpgradeUi" parent="." instance=ExtResource("4_0nay5")]
-visible = false
-layout_mode = 1
-offset_left = 38.0
-offset_top = -15.0
-offset_right = 38.0
-offset_bottom = -15.0
-
 [node name="Border" type="Control" parent="."]
 layout_mode = 1
 anchors_preset = 15
@@ -158,6 +150,14 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.75
 text = "0"
+
+[node name="StatUpgradeUi" parent="." instance=ExtResource("4_0nay5")]
+visible = false
+layout_mode = 1
+offset_left = 38.0
+offset_top = -15.0
+offset_right = 38.0
+offset_bottom = -15.0
 
 [node name="PauseMenu" parent="." instance=ExtResource("5_csnww")]
 visible = false

--- a/scenes/prefabs/ui_elements/option_menu.tscn
+++ b/scenes/prefabs/ui_elements/option_menu.tscn
@@ -1,4 +1,6 @@
-[gd_scene format=3 uid="uid://wuikybn3pwsx"]
+[gd_scene load_steps=2 format=3 uid="uid://df3do2furq7r6"]
+
+[ext_resource type="Script" path="res://scripts/for_scenes/option_menu.gd" id="1_35bgc"]
 
 [node name="OptionMenu" type="Control"]
 layout_mode = 3
@@ -7,6 +9,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("1_35bgc")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -25,3 +28,9 @@ grow_vertical = 2
 [node name="Label" type="Label" parent="VBoxContainer"]
 layout_mode = 2
 text = "Option Menu"
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Back"
+
+[connection signal="pressed" from="VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/scenes/prefabs/ui_elements/pause_menu.tscn
+++ b/scenes/prefabs/ui_elements/pause_menu.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://c05l3ridoi3lc"]
+[gd_scene load_steps=3 format=3 uid="uid://bqwbdvntcsrc0"]
 
 [ext_resource type="Script" path="res://scripts/for_scenes/pause_menu.gd" id="1_j5c0s"]
-[ext_resource type="PackedScene" uid="uid://wuikybn3pwsx" path="res://scenes/prefabs/ui_elements/option_menu.tscn" id="2_piomc"]
+[ext_resource type="PackedScene" uid="uid://df3do2furq7r6" path="res://scenes/prefabs/ui_elements/option_menu.tscn" id="2_piomc"]
 
 [node name="PauseMenu" type="Control"]
 process_mode = 3
@@ -43,9 +43,10 @@ text = "Resume"
 layout_mode = 2
 text = "Quit"
 
-[node name="OptionMenu" parent="." instance=ExtResource("2_piomc")]
+[node name="OptionMenu" parent="." node_paths=PackedStringArray("pause_menu") instance=ExtResource("2_piomc")]
 visible = false
 layout_mode = 1
+pause_menu = NodePath("../PauseMenu")
 
 [connection signal="pressed" from="PauseMenu/VBoxContainer/OptionsToggle" to="." method="_on_options_toggle_pressed"]
 [connection signal="pressed" from="PauseMenu/VBoxContainer/ResumeToggle" to="." method="_on_resume_toggle_pressed"]

--- a/scenes/prefabs/ui_elements/stat_upgrade.tscn
+++ b/scenes/prefabs/ui_elements/stat_upgrade.tscn
@@ -6,6 +6,10 @@
 size_flags_vertical = 3
 script = ExtResource("1_ejj0v")
 
+[node name="TextureRect" type="TextureRect" parent="."]
+layout_mode = 2
+expand_mode = 3
+
 [node name="StatNameLabel" type="Label" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3

--- a/scenes/prefabs/ui_elements/stat_upgrade_ui.tscn
+++ b/scenes/prefabs/ui_elements/stat_upgrade_ui.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://bsmerj830lma6"]
+[gd_scene load_steps=6 format=3 uid="uid://bsmerj830lma6"]
 
 [ext_resource type="PackedScene" uid="uid://bt7w3orvfq2tv" path="res://scenes/prefabs/ui_elements/stat_upgrade.tscn" id="1_ekqrg"]
 [ext_resource type="Script" path="res://scripts/for_scenes/stat_upgrade_ui.gd" id="1_eu2fv"]
+[ext_resource type="Texture2D" uid="uid://cegvvvlsxekts" path="res://assets/ui_renders/HeartIcon.png" id="3_klydc"]
+[ext_resource type="Texture2D" uid="uid://c7bfofw7rd1tu" path="res://assets/ui_renders/FistIcon.png" id="4_0piuq"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_e6vq2"]
 corner_radius_top_left = 25
@@ -53,10 +55,12 @@ layout_mode = 2
 [node name="StatUpgrade" parent="MarginContainer/Panel/MarginContainer/VBoxContainer" instance=ExtResource("1_ekqrg")]
 layout_mode = 2
 stat_name = "health"
+upgrade_icon = ExtResource("3_klydc")
 
 [node name="StatUpgrade2" parent="MarginContainer/Panel/MarginContainer/VBoxContainer" instance=ExtResource("1_ekqrg")]
 layout_mode = 2
 stat_name = "dmg"
+upgrade_icon = ExtResource("4_0piuq")
 
 [node name="StatUpgrade3" parent="MarginContainer/Panel/MarginContainer/VBoxContainer" instance=ExtResource("1_ekqrg")]
 layout_mode = 2

--- a/scripts/for_scenes/option_menu.gd
+++ b/scripts/for_scenes/option_menu.gd
@@ -1,0 +1,7 @@
+extends Control
+
+@export var pause_menu: Control
+
+func _on_back_button_pressed() -> void:
+	self.hide()
+	pause_menu.show()

--- a/scripts/for_scenes/stat_upgrade.gd
+++ b/scripts/for_scenes/stat_upgrade.gd
@@ -1,11 +1,12 @@
 extends HBoxContainer
 
 @export var stat_name: String
-
+@export var upgrade_icon : CompressedTexture2D
 @onready var upgrade_level_label = $"UpgradeLevelLabel"
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	$TextureRect.texture = upgrade_icon
 	var label: Label = $"StatNameLabel"
 	label.text = "Upgrade: " + stat_name
 	SignalBus.update_HUD.connect(update_level_label)


### PR DESCRIPTION
-   Upgrades now have a space for icons
-   Fixed upgrade menu going behind HUD
-   Merged in the foundation of the Options menu from the branch `jackson-jack-options`
-   Changed hotspot for cursor to better match the tip of the sword image.