### PR TITLE
version 0.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -505,3 +505,16 @@
 - Exit now swaps between a static sprite, and an animated sprite depending on whether or not the exit is unlocked yet
 - Health now has a 1/9 chance of dropping instead of a 1/2
 - When quitting from the game, the main menu music will start now 
+
+## version 0.92
+
+- Fixed game crashing bug
+-    Previously, game crashed in levels 2+ because of the mini map
+-    Some part of the mini map caused the game to randomly crash when the player dashed or swung their sword
+-    Temporarily fixed this by commenting out call to configure mini map
+- While attempting to patch this bug, fixed massive memory issues:
+-    Tile map Map and Tile nodes were instanced, but not added to the tree, causing them to not be freed when changing scenes
+-    Changed code to add Map and Tile objects to scene tree when instanced
+-    The same change was made for the Pool object
+-      Each enemy pool is added as a child to the enemy manager (enemies are the only object currently being pooled)
+-      Refactored object pool to instance all objects and turn them off instead of leaving them outside of the scene tree. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -509,12 +509,12 @@
 ## version 0.92
 
 - Fixed game crashing bug:
--    Previously, game crashed in levels 2+ because of the mini map
--    Some part of the mini map caused the game to randomly crash when the player dashed or swung their sword
--    Temporarily fixed this by commenting out call to configure mini map
+    - Previously, game crashed in levels 2+ because of the mini map
+    - Some part of the mini map caused the game to randomly crash when the player dashed or swung their sword
+    - Temporarily fixed this by commenting out call to configure mini map
 - While attempting to patch this bug, fixed massive memory issues:
--    Tile map Map and Tile nodes were instanced, but not added to the tree, causing them to not be freed when changing scenes
--    Changed code to add Map and Tile objects to scene tree when instanced
--    The same change was made for the Pool object
--      Each enemy pool is added as a child to the enemy manager (enemies are the only object currently being pooled)
--      Refactored object pool to instance all objects and turn them off instead of leaving them outside of the scene tree. 
+    - Tile map Map and Tile nodes were instanced, but not added to the tree, causing them to not be freed when changing scenes
+    - Changed code to add Map and Tile objects to scene tree when instanced
+    - The same change was made for the Pool object
+        - Each enemy pool is added as a child to the enemy manager (enemies are the only object currently being pooled)
+        - Refactored object pool to instance all objects and turn them off instead of leaving them outside of the scene tree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,7 +508,7 @@
 
 ## version 0.92
 
-- Fixed game crashing bug
+- Fixed game crashing bug:
 -    Previously, game crashed in levels 2+ because of the mini map
 -    Some part of the mini map caused the game to randomly crash when the player dashed or swung their sword
 -    Temporarily fixed this by commenting out call to configure mini map

--- a/project.godot
+++ b/project.godot
@@ -38,8 +38,8 @@ SaveHandler="*res://save_handler.gd"
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/size/initial_position_type=0
-window/size/window_width_override=1920
-window/size/window_height_override=1080
+window/size/window_width_override=600
+window/size/window_height_override=600
 window/stretch/mode="viewport"
 mouse_cursor/custom_image="res://assets/images/cursorV3.png"
 

--- a/project.godot
+++ b/project.godot
@@ -38,8 +38,8 @@ SaveHandler="*res://save_handler.gd"
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/size/initial_position_type=0
-window/size/window_width_override=600
-window/size/window_height_override=600
+window/size/window_width_override=1920
+window/size/window_height_override=1080
 window/stretch/mode="viewport"
 mouse_cursor/custom_image="res://assets/images/cursorV3.png"
 

--- a/scenes/prefabs/sceF167.tmp
+++ b/scenes/prefabs/sceF167.tmp
@@ -1,0 +1,58 @@
+[gd_scene load_steps=8 format=3 uid="uid://bugqksfg6vdn7"]
+
+[ext_resource type="Script" path="res://scenes/prefabs/scene_config_package.gd" id="1_qcfrr"]
+[ext_resource type="PackedScene" uid="uid://b0qchcd21rx5b" path="res://scenes/level_generator.tscn" id="2_1eor7"]
+[ext_resource type="PackedScene" uid="uid://c6kyubdgubp47" path="res://scenes/prefabs/player/player.tscn" id="3_5fksv"]
+[ext_resource type="PackedScene" uid="uid://c611v6n8n75j1" path="res://scenes/prefabs/custom_camera.tscn" id="4_t24gl"]
+[ext_resource type="Script" path="res://scripts/enemy_manager.gd" id="5_e7sx3"]
+[ext_resource type="PackedScene" uid="uid://dfvsgbamdsiep" path="res://scenes/prefabs/ui_elements/HUD.tscn" id="6_14c2j"]
+[ext_resource type="Script" path="res://item_manager.gd" id="10_ww6gq"]
+
+[node name="Scene Config Package" type="Node2D" node_paths=PackedStringArray("level_generator", "camera", "player", "hud")]
+z_as_relative = false
+y_sort_enabled = true
+script = ExtResource("1_qcfrr")
+level_generator = NodePath("Level Generator")
+camera = NodePath("Custom Camera")
+player = NodePath("Player")
+hud = NodePath("CanvasLayer/HUD")
+
+[node name="Level Generator" parent="." instance=ExtResource("2_1eor7")]
+world_seed = 2
+randomize_seed = null
+
+[node name="Player" parent="." instance=ExtResource("3_5fksv")]
+
+[node name="Animation Manager" parent="Player" index="0"]
+animation = &"death"
+
+[node name="WallTransparencyCollision" type="CollisionShape2D" parent="Player"]
+
+[node name="Custom Camera" parent="." node_paths=PackedStringArray("target") instance=ExtResource("4_t24gl")]
+zoom = Vector2(0.8, 0.8)
+target = NodePath("../Player")
+follow_player = true
+free_axis = {
+"x": 10,
+"y": 10
+}
+
+[node name="Enemy Manager" type="Node" parent="." node_paths=PackedStringArray("level_generator", "item_manager") groups=["Enemy_Manager"]]
+script = ExtResource("5_e7sx3")
+level_generator = NodePath("../Level Generator")
+item_manager = NodePath("../ItemManager")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="HUD" parent="CanvasLayer" instance=ExtResource("6_14c2j")]
+
+[node name="ItemManager" type="Node" parent="."]
+script = ExtResource("10_ww6gq")
+
+[editable path="Level Generator"]
+[editable path="Player"]
+[editable path="Player/State Machine"]
+[editable path="Player/Hitbox"]
+[editable path="Player/Hurtbox"]
+[editable path="Player/Direction Manager"]
+[editable path="Player/Pick Up"]

--- a/scenes/prefabs/sceF80.tmp
+++ b/scenes/prefabs/sceF80.tmp
@@ -1,0 +1,57 @@
+[gd_scene load_steps=8 format=3 uid="uid://bugqksfg6vdn7"]
+
+[ext_resource type="Script" path="res://scenes/prefabs/scene_config_package.gd" id="1_qcfrr"]
+[ext_resource type="PackedScene" uid="uid://b0qchcd21rx5b" path="res://scenes/level_generator.tscn" id="2_1eor7"]
+[ext_resource type="PackedScene" uid="uid://c6kyubdgubp47" path="res://scenes/prefabs/player/player.tscn" id="3_5fksv"]
+[ext_resource type="PackedScene" uid="uid://c611v6n8n75j1" path="res://scenes/prefabs/custom_camera.tscn" id="4_t24gl"]
+[ext_resource type="Script" path="res://scripts/enemy_manager.gd" id="5_e7sx3"]
+[ext_resource type="PackedScene" uid="uid://dfvsgbamdsiep" path="res://scenes/prefabs/ui_elements/HUD.tscn" id="6_14c2j"]
+[ext_resource type="Script" path="res://item_manager.gd" id="10_ww6gq"]
+
+[node name="Scene Config Package" type="Node2D" node_paths=PackedStringArray("level_generator", "camera", "player", "hud")]
+z_as_relative = false
+y_sort_enabled = true
+script = ExtResource("1_qcfrr")
+level_generator = NodePath("Level Generator")
+camera = NodePath("Custom Camera")
+player = NodePath("Player")
+hud = NodePath("CanvasLayer/HUD")
+
+[node name="Level Generator" parent="." instance=ExtResource("2_1eor7")]
+world_seed = 2
+
+[node name="Player" parent="." instance=ExtResource("3_5fksv")]
+
+[node name="Animation Manager" parent="Player" index="0"]
+animation = &"death"
+
+[node name="WallTransparencyCollision" type="CollisionShape2D" parent="Player"]
+
+[node name="Custom Camera" parent="." node_paths=PackedStringArray("target") instance=ExtResource("4_t24gl")]
+zoom = Vector2(0.8, 0.8)
+target = NodePath("../Player")
+follow_player = true
+free_axis = {
+"x": 10,
+"y": 10
+}
+
+[node name="Enemy Manager" type="Node" parent="." node_paths=PackedStringArray("level_generator", "item_manager") groups=["Enemy_Manager"]]
+script = ExtResource("5_e7sx3")
+level_generator = NodePath("../Level Generator")
+item_manager = NodePath("../ItemManager")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="HUD" parent="CanvasLayer" instance=ExtResource("6_14c2j")]
+
+[node name="ItemManager" type="Node" parent="."]
+script = ExtResource("10_ww6gq")
+
+[editable path="Level Generator"]
+[editable path="Player"]
+[editable path="Player/State Machine"]
+[editable path="Player/Hitbox"]
+[editable path="Player/Hurtbox"]
+[editable path="Player/Direction Manager"]
+[editable path="Player/Pick Up"]

--- a/scenes/prefabs/scene_config_package.gd
+++ b/scenes/prefabs/scene_config_package.gd
@@ -13,7 +13,7 @@ func _ready():
 	'''
 	
 	level_generator.generate_level(LevelManager.get_current_package())
-	config_mini_map()
+	#config_mini_map()
 	place_player()
 	play_music()
 

--- a/scenes/prefabs/scene_config_package.gd
+++ b/scenes/prefabs/scene_config_package.gd
@@ -13,7 +13,9 @@ func _ready():
 	'''
 	
 	level_generator.generate_level(LevelManager.get_current_package())
-	#config_mini_map()
+
+	# to configure mini-map: config_mini_map()
+
 	place_player()
 	play_music()
 

--- a/scenes/prefabs/scene_config_package.tscn
+++ b/scenes/prefabs/scene_config_package.tscn
@@ -19,6 +19,7 @@ hud = NodePath("CanvasLayer/HUD")
 
 [node name="Level Generator" parent="." instance=ExtResource("2_1eor7")]
 world_seed = 2
+randomize_seed = null
 
 [node name="Player" parent="." instance=ExtResource("3_5fksv")]
 

--- a/scripts/enemy_manager.gd
+++ b/scripts/enemy_manager.gd
@@ -26,14 +26,13 @@ func _ready():
 	required_enemies = enemy_package.required_enemies
 	
 	var accumulated_odds = 0
-	var scene = get_tree().root
 	for enemy in enemy_package.enemy_types:
 		accumulated_odds+= enemy.frequency
 		enemy_odds.append( { "name": enemy.name, "odds": accumulated_odds}  )
 	for enemy in enemy_package.enemy_types:
-		var pool =Pool.new( name_to_path[enemy.name] , enemy.pool_size )
+		var pool = Pool.new( self, name_to_path[enemy.name] , enemy.pool_size )
 		enemy_pools[enemy.name] = pool
-		scene.add_child(pool)
+		self.add_child(pool)
 		
 func enemy_killed(enemy):
 	live_enemies -= 1
@@ -48,7 +47,6 @@ func enemy_killed(enemy):
 	else:
 		drop_name = "currency"
 	item_manager.spawn_item(drop_name, enemy.position)
-	death_drop()
 	SignalBus.enemy_killed.emit(enemies_killed)
 	ScoreManager.increase_score(1)
 	if enemies_killed >= required_enemies:
@@ -58,16 +56,10 @@ func enemy_killed(enemy):
 	enemy_pools[enemy.type].kill(enemy)
 
 
-func death_drop():
-	
-	pass
-
-
 func spawn_enemy(pos, enemy_type = null):
 	if enemy_type == null || ! ( enemy_pools[enemy_type].collection.size() >= 0 )  || live_enemies >= max_concurrent_enemies:
 		return null
-	var new_enemy = enemy_pools[enemy_type].add(get_tree().current_scene)
-	new_enemy.global_position = pos
+	var new_enemy = enemy_pools[enemy_type].add(pos)
 	live_enemies+=1
 	enemies_spawned += 1
 	pass

--- a/scripts/enemy_manager.gd
+++ b/scripts/enemy_manager.gd
@@ -55,7 +55,6 @@ func enemy_killed(enemy):
 		
 	enemy_pools[enemy.type].kill(enemy)
 
-
 func spawn_enemy(pos, enemy_type = null):
 	if enemy_type == null || ! ( enemy_pools[enemy_type].collection.size() >= 0 )  || live_enemies >= max_concurrent_enemies:
 		return null
@@ -63,7 +62,6 @@ func spawn_enemy(pos, enemy_type = null):
 	live_enemies+=1
 	enemies_spawned += 1
 	pass
-
 
 func _process(delta):
 	'''
@@ -91,7 +89,6 @@ func try_spawn():
 		if (player.position - true_pos).length() > min_dist_from_player:
 			
 			spawn_enemy(true_pos, pick_rand_enemy())
-
 
 func pick_rand_enemy():
 	var chance = randf_range(0,1)

--- a/scripts/enemy_manager.gd
+++ b/scripts/enemy_manager.gd
@@ -26,13 +26,15 @@ func _ready():
 	required_enemies = enemy_package.required_enemies
 	
 	var accumulated_odds = 0
-	
+	var scene = get_tree().root
 	for enemy in enemy_package.enemy_types:
 		accumulated_odds+= enemy.frequency
 		enemy_odds.append( { "name": enemy.name, "odds": accumulated_odds}  )
 	for enemy in enemy_package.enemy_types:
-		enemy_pools[enemy.name] = Pool.new( name_to_path[enemy.name] , enemy.pool_size )
-
+		var pool =Pool.new( name_to_path[enemy.name] , enemy.pool_size )
+		enemy_pools[enemy.name] = pool
+		scene.add_child(pool)
+		
 func enemy_killed(enemy):
 	live_enemies -= 1
 	enemies_killed += 1

--- a/scripts/for_scenes/object_pool.gd
+++ b/scripts/for_scenes/object_pool.gd
@@ -13,7 +13,6 @@ func _init(root: Node, ref: String, amount):
 		collection.append(instance)
 		root.add_child(instance)
 
-
 func kill(object: Node):
 	turn_off(object)
 
@@ -25,7 +24,6 @@ func add( position = Vector2.ZERO):
 	if object.position:
 		object.position = position
 	turn_on(object)
-
 
 func turn_off(object):
 	object.set_process(false)

--- a/scripts/for_scenes/object_pool.gd
+++ b/scripts/for_scenes/object_pool.gd
@@ -1,3 +1,4 @@
+extends Node
 class_name Pool
 
 var path : String
@@ -9,7 +10,9 @@ func _init(ref: String, amount):
 	entity = load(ref)
 	
 	for items in range(amount):
-		collection.append(entity.instantiate())
+		var instance =entity.instantiate()
+		collection.append(instance)
+		Globals.orphans.append(instance)
 
 func kill(object):
 	object.get_parent().remove_child(object)

--- a/scripts/for_scenes/object_pool.gd
+++ b/scripts/for_scenes/object_pool.gd
@@ -5,30 +5,40 @@ var path : String
 var entity
 var collection = []
 
-func _init(ref: String, amount):
+func _init(root: Node, ref: String, amount):
 	path = ref
 	entity = load(ref)
-	
 	for items in range(amount):
-		var instance =entity.instantiate()
+		var instance = entity.instantiate()
 		collection.append(instance)
-		Globals.orphans.append(instance)
-
-func kill(object):
-	object.get_parent().remove_child(object)
-	collection.append(object)
-	if object.reset:
-		object.reset()
+		root.add_child(instance)
 
 
-func add(parent):
+func kill(object: Node):
+	turn_off(object)
+
+func add( position = Vector2.ZERO):
 	if (collection.size() <= 0 ):
 		print("pool is empty")
 		return null
 	var object = collection.pop_back()
-	call_deferred("add_to_tree", parent, object)
-	return (object)
+	if object.position:
+		object.position = position
+	turn_on(object)
 
-# seperated this into a function so I could defer the call.
-func add_to_tree(root, object):
-	root.add_child(object)
+
+func turn_off(object):
+	object.set_process(false)
+	object.set_physics_process(false)
+	if object.has_method("hide"):
+		object.hide()
+	for child in object.get_children():
+		turn_off(child)
+
+func turn_on(object):
+	object.set_process(true)
+	object.set_physics_process(true)
+	if object.has_method("show"):
+		object.show()
+	for child in object.get_children():
+		turn_on(child)

--- a/scripts/globals/globals.gd
+++ b/scripts/globals/globals.gd
@@ -31,11 +31,5 @@ func change_scene(scene: PackedScene):
 #notifies systems that game is going to quit, then quits
 func quit_game():
 	SaveHandler.save_game()
-	remove_orphans()
 	get_tree().root.propagate_notification(NOTIFICATION_WM_CLOSE_REQUEST)
 	get_tree().quit()
-
-func remove_orphans():
-	for orphan in orphans:
-		orphan.free()
-	orphans = []

--- a/scripts/globals/globals.gd
+++ b/scripts/globals/globals.gd
@@ -3,7 +3,7 @@ extends Node
 var player: CharacterBody2D = null
 var currency_key: String = "money"
 var levels = ["Limbo", "Lust"]
-
+var orphans = []
 
 var current_level = {
 	"level":levels[0],
@@ -31,5 +31,11 @@ func change_scene(scene: PackedScene):
 #notifies systems that game is going to quit, then quits
 func quit_game():
 	SaveHandler.save_game()
+	remove_orphans()
 	get_tree().root.propagate_notification(NOTIFICATION_WM_CLOSE_REQUEST)
 	get_tree().quit()
+
+func remove_orphans():
+	for orphan in orphans:
+		orphan.free()
+	orphans = []

--- a/scripts/level_generator.gd
+++ b/scripts/level_generator.gd
@@ -67,9 +67,8 @@ func generate_level(level_package):
 	prep()
 	size.x = package.width
 	size.y = package.height
-	var root = get_tree().root
-	map = Map.new(root,size, world_seed)
-	root.add_child(map)
+	map = Map.new(size, world_seed)
+	self.add_child(map)
 	
 	# TODO - fill this out as more methods are made.
 	# We may want to use noise or wave collapse function or a modified walk

--- a/scripts/level_generator.gd
+++ b/scripts/level_generator.gd
@@ -67,7 +67,9 @@ func generate_level(level_package):
 	prep()
 	size.x = package.width
 	size.y = package.height
-	map = Map.new(size, world_seed)
+	var root = get_tree().root
+	map = Map.new(root,size, world_seed)
+	root.add_child(map)
 	
 	# TODO - fill this out as more methods are made.
 	# We may want to use noise or wave collapse function or a modified walk

--- a/scripts/map.gd
+++ b/scripts/map.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends Node
 class_name Map
 
 @export var size: Vector2i = Vector2i.ZERO
@@ -8,26 +8,29 @@ var noise_ref = FastNoiseLite.new()
 var threshold = .3
 var player_spawn = Vector2i.ZERO
 var end = Vector2i.ZERO
+var root
 var step_points = [
 	Vector2i.ZERO
 ]
 
-func _init(arg_size, arg_seed):
+func _init(root_arg, arg_size, arg_seed):
 	size = arg_size
 	seed = arg_seed
 	noise_ref.seed = seed
+	root = root_arg
 	configure_matrix()
 
 func configure_matrix():
 	'''
 	Fill matrix with tiles.
 	'''
-	
 	for y in range (size.y):
 		matrix.append([])
 		
 		for x in range(size.x):
-			matrix[y].append( Tile.new() )
+			var tile = Tile.new()
+			matrix[y].append( tile )
+			root.add_child(tile)
 
 func get_tile(pos):
 	return matrix[pos.y][pos.x]

--- a/scripts/map.gd
+++ b/scripts/map.gd
@@ -13,11 +13,10 @@ var step_points = [
 	Vector2i.ZERO
 ]
 
-func _init(root_arg, arg_size, arg_seed):
+func _init(arg_size, arg_seed):
 	size = arg_size
 	seed = arg_seed
 	noise_ref.seed = seed
-	root = root_arg
 	configure_matrix()
 
 func configure_matrix():
@@ -30,7 +29,7 @@ func configure_matrix():
 		for x in range(size.x):
 			var tile = Tile.new()
 			matrix[y].append( tile )
-			root.add_child(tile)
+			self.add_child(tile)
 
 func get_tile(pos):
 	return matrix[pos.y][pos.x]

--- a/scripts/navigator.gd
+++ b/scripts/navigator.gd
@@ -6,12 +6,19 @@ class_name Navigator
 @export var character: CharacterBody2D
 var timer: Timer
 var update_path_on_timer: bool = false
+var prepped = false
 
 func _ready():
+	NavigationServer2D.map_changed.connect(connected_to_map)
 	make_timer()
+
+func connected_to_map(_unused):
+	prepped = true
 
 
 func get_next_step():
+	if !prepped:
+		return character.position
 	return get_next_path_position()
 
 


### PR DESCRIPTION
- Fixed game crashing bug
-    Previously, game crashed in levels 2+ because of the mini map
-    Some part of the mini map caused the game to randomly crash when the player dashed or swung their sword
-    Temporarily fixed this by commenting out call to configure mini map
- While attempting to patch this bug, fixed massive memory issues:
-    Tile map Map and Tile nodes were instanced, but not added to the tree, causing them to not be freed when changing scenes
-    Changed code to add Map and Tile objects to scene tree when instanced
-    The same change was made for the Pool object
-      Each enemy pool is added as a child to the enemy manager (enemies are the only object currently being pooled)
-      Refactored object pool to instance all objects and turn them off instead of leaving them outside of the scene tree. 